### PR TITLE
Add DB check to avoid repeated fitbit calls

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -94,3 +94,26 @@ def update_rol(record_id, rol):
         (rol, record_id)
     )
     conn.commit()
+
+
+def count_records():
+    """Retorna el nombre total de registres"""
+    init_db()
+    cur = conn.execute('SELECT COUNT(*) AS total FROM fitbit_data')
+    return cur.fetchone()['total']
+
+
+def get_latest_record():
+    """Obté el darrer registre guardat"""
+    init_db()
+    cur = conn.execute('SELECT * FROM fitbit_data ORDER BY date DESC, id DESC LIMIT 1')
+    row = cur.fetchone()
+    return dict(row) if row else None
+
+
+def get_record_for_date(date_str):
+    """Retorna el darrer registre d'una data concreta"""
+    init_db()
+    cur = conn.execute('SELECT * FROM fitbit_data WHERE date = ? ORDER BY id DESC LIMIT 1', (date_str,))
+    row = cur.fetchone()
+    return dict(row) if row else None

--- a/backend/fitbit_fetch.py
+++ b/backend/fitbit_fetch.py
@@ -3,24 +3,34 @@ Run fitbit_raw.py i retorna el dataframe com una llista JSON.
 
 """
 
-import importlib.util, json, pandas as pd
+import importlib.util
+import pandas as pd
 from pathlib import Path
+import datetime as dt
 
 import db
 
 RAW_PATH = Path(__file__).with_name("fitbit_raw.py")
 
 def fetch_fitbit_data() -> list[dict]:
+    """Retorna les dades Fitbit evitant duplicar peticions"""
+    today = dt.date.today().strftime("%Y-%m-%d")
+
+    # Si ja tenim dades d'avui, retornem l'últim registre
+    if db.count_records() > 0:
+        record = db.get_record_for_date(today)
+        if record:
+            return [record]
+
+    # En cas contrari executem fitbit_raw.py
     spec = importlib.util.spec_from_file_location("fitbit_raw", RAW_PATH)
     fitbit_raw = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(fitbit_raw)  # executa el script
 
     if not hasattr(fitbit_raw, "df"):
         raise RuntimeError("fitbit_raw.py no hi ha definit un datafreame anomenat 'df'.")
-    
-    # Convertim els NaNs en None pel json
+
     records = fitbit_raw.df.where(~fitbit_raw.df.isna(), None).to_dict(orient="records")
-    # Guardem les dades a la base de dades
     db.insert_records(records)
     return records
 


### PR DESCRIPTION
## Summary
- add helpers in `db.py` to query existing records
- skip `fitbit_raw.py` if today's data already exists

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d61494c48331b02e3ec0d45aa1c6