### PR TITLE
Load user profile from database

### DIFF
--- a/backend/fitbit_fetch.py
+++ b/backend/fitbit_fetch.py
@@ -107,7 +107,33 @@ def _init_db():
         );
         """
         cursor.execute(create_user_profile_table_sql)
-        conn.commit() # Commit after all table creations
+
+        # Insereix un perfil per defecte si la taula és buida
+        cursor.execute(f"SELECT COUNT(*) FROM {PROFILE_TABLE_NAME}")
+        if cursor.fetchone()[0] == 0:
+            default_profile = {
+                "user_id": "default",
+                "main_training_goal": "Mantenimient general",
+                "experience_level": "Principiant",
+                "training_days_per_week": 3,
+                "training_minutes_per_session": 30,
+                "available_equipment": json.dumps(["Pes corporal / sense material"]),
+                "activity_preferences": json.dumps(["Cardio"]),
+                "weekly_schedule": json.dumps({
+                    "Lunes": ["17:00", "19:00"],
+                    "Miércoles": ["17:00", "19:00"],
+                    "Viernes": ["17:00", "19:00"],
+                }),
+                "medical_conditions": "None",
+            }
+            columns = ", ".join(default_profile.keys())
+            placeholders = ", ".join(["?"] * len(default_profile))
+            cursor.execute(
+                f"INSERT INTO {PROFILE_TABLE_NAME} ({columns}) VALUES ({placeholders})",
+                tuple(default_profile.values()),
+            )
+
+        conn.commit()  # Commit after all table creations i possibles insercions
         
         # Assegura que totes les columnes (incloent les de features/prediccions) existeixen per a la taula TABLE_NAME
         _add_missing_columns(conn)
@@ -300,6 +326,30 @@ def fetch_fitbit_data() -> list[dict]:
     
     print(f"\n--- Pipeline finalitzat. No hi ha dades disponibles per a {yesterday_str} ---")
     return []
+
+
+def fetch_user_profile(user_id: str = "default") -> dict:
+    """Recupera el perfil d'usuari de la BD."""
+    _init_db()
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT * FROM {PROFILE_TABLE_NAME} WHERE user_id = ?", (user_id,))
+        row = cursor.fetchone()
+        if not row:
+            return {}
+        cols = [d[0] for d in cursor.description]
+        profile = dict(zip(cols, row))
+        for field in ("available_equipment", "activity_preferences", "weekly_schedule"):
+            if profile.get(field):
+                profile[field] = json.loads(profile[field])
+        return profile
+    except sqlite3.Error as e:
+        print(f"[fetch_user_profile] Error: {e}")
+        return {}
+    finally:
+        if 'conn' in locals() and conn:
+            conn.close()
 
 
 if __name__ == "__main__":

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 
-from fitbit_fetch import fetch_fitbit_data
+from fitbit_fetch import fetch_fitbit_data, fetch_user_profile
 from ai import get_recommendation
 
 import numpy as np
@@ -76,6 +76,12 @@ def get_fitbit_data() -> dict:
     return jsonable_encoder(record, exclude_none=True)
 
 
+def get_user_profile() -> dict:
+    """Obté el perfil d'usuari de la BD i el prepara per enviar."""
+    profile = fetch_user_profile()
+    return jsonable_encoder(profile, exclude_none=True)
+
+
 # ---------- Endpoints --------------------------------------------------------
 @app.get("/fitbit-data")
 def fitbit_data():
@@ -84,6 +90,16 @@ def fitbit_data():
         return JSONResponse(content=payload)
     except Exception as exc:
         log.exception("/fitbit-data failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/user-profile")
+def user_profile():
+    try:
+        payload = get_user_profile()
+        return JSONResponse(content=payload)
+    except Exception as exc:
+        log.exception("/user-profile failed")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 

--- a/frontend/src/components/ProfileModal.jsx
+++ b/frontend/src/components/ProfileModal.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import useUserProfile from '../hooks/useUserProfile'; // Hook per llegir el perfil
 import './ProfileModal.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUser, faTimes, faCalendarAlt, faClock, faDumbbell, faPersonRunning, faBullseye, faStar, faCheckSquare, faSquare } from '@fortawesome/free-solid-svg-icons';
@@ -86,18 +87,71 @@ const ProfileModal = ({ isOpen, onClose, userData }) => {
   );
   const [trainingSchedule, setTrainingSchedule] = useState(initialTrainingSchedule);
 
-  // Effect to update profile states if userData changes and contains these fields
+  const { data: profileData } = useUserProfile(); // Obté el perfil guardat a la BD
+
+  // Actualitza els estats del perfil quan arriben dades del backend o de les prop
   useEffect(() => {
-    if (userData) {
-      setMainGoal(userData.mainGoal || mainGoalOptions[0].value);
-      setExperienceLevel(userData.experienceLevel || experienceLevelOptions[0].value);
-      setTrainingDaysPerWeek(userData.trainingDaysPerWeek || trainingDaysOptions[2].value);
-      setTrainingMinutesPerSession(userData.trainingMinutesPerSession || trainingMinutesOptions[3].value);
-      setAvailableEquipment(prev => equipmentOptions.reduce((acc, curr) => ({ ...acc, [curr.id]: userData.availableEquipment?.[curr.id] || false }), {}));
-      setActivityPreferences(prev => activityPreferenceOptions.reduce((acc, curr) => ({ ...acc, [curr.id]: userData.activityPreferences?.[curr.id] || false }), {}));
-      setTrainingSchedule(userData.trainingSchedule || initialTrainingSchedule);
+    const source = profileData || userData;
+    if (source) {
+      setMainGoal(source.main_training_goal || source.mainGoal || mainGoalOptions[0].value);
+      setExperienceLevel(source.experience_level || source.experienceLevel || experienceLevelOptions[0].value);
+      setTrainingDaysPerWeek(source.training_days_per_week || source.trainingDaysPerWeek || trainingDaysOptions[2].value);
+      setTrainingMinutesPerSession(source.training_minutes_per_session || source.trainingMinutesPerSession || trainingMinutesOptions[3].value);
+
+      const equipList = source.available_equipment || source.availableEquipment;
+      setAvailableEquipment(
+        equipmentOptions.reduce(
+          (acc, curr) => ({
+            ...acc,
+            [curr.id]: Array.isArray(equipList)
+              ? equipList.includes(curr.label) || equipList.includes(curr.id)
+              : equipList?.[curr.id] || false,
+          }),
+          {}
+        )
+      );
+
+      const prefList = source.activity_preferences || source.activityPreferences;
+      setActivityPreferences(
+        activityPreferenceOptions.reduce(
+          (acc, curr) => ({
+            ...acc,
+            [curr.id]: Array.isArray(prefList)
+              ? prefList.includes(curr.label) || prefList.includes(curr.id)
+              : prefList?.[curr.id] || false,
+          }),
+          {}
+        )
+      );
+
+      const schedule = source.weekly_schedule || source.trainingSchedule;
+      if (schedule) {
+        const mapDay = {
+          Lunes: 'dilluns',
+          Martes: 'dimarts',
+          Miércoles: 'dimecres',
+          Jueves: 'dijous',
+          Viernes: 'divendres',
+          Sabado: 'dissabte',
+          Domingo: 'diumenge',
+        };
+        const newSchedule = { ...initialTrainingSchedule };
+        Object.entries(schedule).forEach(([day, range]) => {
+          const catDay = mapDay[day] || day;
+          if (newSchedule[catDay]) {
+            newSchedule[catDay] = {
+              enabled: true,
+              from: range[0],
+              to: range[1],
+            };
+          }
+        });
+        setTrainingSchedule(newSchedule);
+      } else {
+        setTrainingSchedule(initialTrainingSchedule);
+      }
     }
-  }, [userData]);
+  }, [profileData, userData]);
 
   if (!isOpen) return null;
 

--- a/frontend/src/hooks/useUserProfile.js
+++ b/frontend/src/hooks/useUserProfile.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+
+// Hook per obtenir el perfil d'usuari des del backend
+
+export default function useUserProfile() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch("http://localhost:8000/user-profile")
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then(j => setData(j))
+      .catch(e => setError(e))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Retorna l'estat del perfil i indicadors de càrrega o error
+  return { data, loading, error };
+}


### PR DESCRIPTION
## Summary
- add default user profile row to `user_profile` table
- provide `fetch_user_profile` util in backend
- expose `/user-profile` endpoint
- add `useUserProfile` hook for frontend
- load profile data from backend inside `ProfileModal`

## Testing
- `python -m py_compile backend/*.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846dd30382c8331a537bfb9dbb27cee