### PR TITLE
Persist profile updates to database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules/
 # Python
 __pycache__/
 *.egg-info/
+dist/

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 
-from fitbit_fetch import fetch_fitbit_data
+from fitbit_fetch import fetch_fitbit_data, fetch_user_profile, update_user_profile
 from ai import get_recommendation
 
 import numpy as np
@@ -76,6 +76,12 @@ def get_fitbit_data() -> dict:
     return jsonable_encoder(record, exclude_none=True)
 
 
+def get_user_profile() -> dict:
+    """Obté el perfil d'usuari de la BD i el prepara per enviar."""
+    profile = fetch_user_profile()
+    return jsonable_encoder(profile, exclude_none=True)
+
+
 # ---------- Endpoints --------------------------------------------------------
 @app.get("/fitbit-data")
 def fitbit_data():
@@ -84,6 +90,26 @@ def fitbit_data():
         return JSONResponse(content=payload)
     except Exception as exc:
         log.exception("/fitbit-data failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/user-profile")
+def user_profile():
+    try:
+        payload = get_user_profile()
+        return JSONResponse(content=payload)
+    except Exception as exc:
+        log.exception("/user-profile failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.post("/user-profile")
+def save_user_profile(payload: dict):
+    try:
+        update_user_profile(payload)
+        return {"status": "ok"}
+    except Exception as exc:
+        log.exception("/user-profile POST failed")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 

--- a/frontend/src/hooks/useUserProfile.js
+++ b/frontend/src/hooks/useUserProfile.js
@@ -1,0 +1,39 @@
+import { useState, useEffect } from "react";
+
+// Hook per obtenir el perfil d'usuari des del backend
+
+export default function useUserProfile() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch("http://localhost:8000/user-profile")
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then(j => setData(j))
+      .catch(e => setError(e))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Desa el perfil al backend i actualitza l'estat local
+  const saveProfile = async profile => {
+    try {
+      const r = await fetch("http://localhost:8000/user-profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(profile),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setData(profile);
+    } catch (e) {
+      setError(e);
+      throw e;
+    }
+  };
+
+  // Retorna l'estat del perfil i indicadors de càrrega o error
+  return { data, loading, error, saveProfile };
+}


### PR DESCRIPTION
## Summary
- add `update_user_profile` helper to write profile changes to SQLite
- expose POST `/user-profile` endpoint in FastAPI
- extend `useUserProfile` hook with `saveProfile`
- send updated profile from `ProfileModal`
- ignore `dist/` build artifacts

## Testing
- `python -m py_compile backend/*.py`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846dd30382c8331a537bfb9dbb27cee