### PR TITLE
Implement backend profile persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignorar dependencias
 node_modules/
 
+# Build de frontend
+frontend/dist/
+
 
 # Entornos y datos privados
 .venv/

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 
-from fitbit_fetch import fetch_fitbit_data, fetch_user_profile
+from fitbit_fetch import fetch_fitbit_data, fetch_user_profile, save_user_profile
 from ai import get_recommendation
 
 import numpy as np
@@ -100,6 +100,19 @@ def user_profile():
         return JSONResponse(content=payload)
     except Exception as exc:
         log.exception("/user-profile failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.post("/user-profile")
+def update_user_profile(payload: dict):
+    """Rep un perfil i l'emmagatzema a la BD."""
+    try:
+        ok = save_user_profile(payload)
+        if not ok:
+            raise HTTPException(status_code=500, detail="No s'ha pogut guardar el perfil")
+        return {"status": "ok"}
+    except Exception as exc:
+        log.exception("/user-profile POST failed")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 

--- a/frontend/src/components/ProfileModal.jsx
+++ b/frontend/src/components/ProfileModal.jsx
@@ -166,19 +166,47 @@ const ProfileModal = ({ isOpen, onClose, userData }) => {
     }));
   };
 
-  const handleSave = () => {
-    const profileData = {
-      mainGoal,
-      experienceLevel,
-      trainingDaysPerWeek,
-      trainingMinutesPerSession,
-      availableEquipment,
-      activityPreferences,
-      trainingSchedule
+  const handleSave = async () => {
+    // Converteix els estats del formulari al format que espera el backend
+    const equipArray = Object.keys(availableEquipment).filter(k => availableEquipment[k]);
+    const prefArray = Object.keys(activityPreferences).filter(k => activityPreferences[k]);
+
+    const mapDay = {
+      dilluns: 'Lunes',
+      dimarts: 'Martes',
+      dimecres: 'Miércoles',
+      dijous: 'Jueves',
+      divendres: 'Viernes',
+      dissabte: 'Sabado',
+      diumenge: 'Domingo',
     };
-    console.log('Saving Profile Data:', profileData);
-    // Logic to save data will go here
-    onClose(); // Close modal after save
+    const schedule = {};
+    Object.entries(trainingSchedule).forEach(([day, info]) => {
+      if (info.enabled) schedule[mapDay[day] || day] = [info.from, info.to];
+    });
+
+    const payload = {
+      main_training_goal: mainGoal,
+      experience_level: experienceLevel,
+      training_days_per_week: trainingDaysPerWeek,
+      training_minutes_per_session: trainingMinutesPerSession,
+      available_equipment: equipArray,
+      activity_preferences: prefArray,
+      weekly_schedule: schedule,
+    };
+
+    try {
+      const r = await fetch('http://localhost:8000/user-profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!r.ok) throw new Error('Error al desar el perfil');
+    } catch (e) {
+      console.error('Error guardant el perfil:', e);
+    } finally {
+      onClose();
+    }
   };
 
   const renderCheckboxGroup = (options, state, handler, groupName) => (


### PR DESCRIPTION
## Summary
- allow saving edited profile into DB
- expose POST `/user-profile` endpoint
- persist profile changes from the ProfileModal
- ignore built frontend files

## Testing
- `python -m py_compile backend/main.py backend/fitbit_fetch.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68476753e4bc8331bbbec618fe24f111