### PR TITLE
Activate AI assistant widget

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -116,15 +116,15 @@ def update_user_profile(payload: dict):
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
-# De moment no toquem la recomanació
-# @app.post("/recommend")
-# def recommend(payload: dict):
-#     try:
-#         text = get_recommendation(payload)
-#         return {"text": text}
-#     except Exception as exc:
-#         log.exception("/recommend failed")
-#         raise HTTPException(status_code=500, detail=str(exc)) from exc
+@app.post("/recommend")
+def recommend(payload: dict):
+    """Genera una recomanació personalitzada a partir de les dades Fitbit."""
+    try:
+        text = get_recommendation(payload)
+        return {"text": text}
+    except Exception as exc:
+        log.exception("/recommend failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 if __name__ == "__main__":
     import uvicorn

--- a/frontend/src/components/Dashboard/AIAssistantWidget.jsx
+++ b/frontend/src/components/Dashboard/AIAssistantWidget.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faRobot } from '@fortawesome/free-solid-svg-icons';
+import useRecommendation from '../../hooks/useRecomendation';
+
+export default function AIAssistantWidget({ fitbitData }) {
+  // Estat i funcions del hook de recomanacions
+  const { rec, loading, error, generate } = useRecommendation();
+
+  // Envia les dades de Fitbit al backend per generar recomanació
+  const handleRecommend = () => {
+    if (!loading) generate(fitbitData || {});
+  };
+
+  return (
+    <div className="widget ai-assistant-widget">
+      <h3><FontAwesomeIcon icon={faRobot} /> Assistent IA</h3>
+      <div className="widget-content">
+        <div className="recommendation-area">
+          {loading && <p>Generant recomanació...</p>}
+          {error && <p style={{ color: 'var(--danger)' }}>{error}</p>}
+          {rec && <p>{rec}</p>}
+        </div>
+        {rec ? (
+          <>
+            <p>Vols generar o modificar el teu pla d'entrenament, basat en les noves dades i la recomanació?</p>
+            <div className="widget-actions">
+              {/* Botó deshabilitat temporalment */}
+              <button className="btn btn-secondary" disabled>Pla d'Entrenament (Pròximament...)</button>
+            </div>
+          </>
+        ) : (
+          <div className="widget-actions">
+            <button className="btn btn-primary" onClick={handleRecommend} disabled={loading}>Recomanació</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/components/Dashboard/Dashboard.jsx
@@ -12,6 +12,7 @@ import ActivityWidget from './ActivityWidget';
 import BiomarkersWidget from './BiomarkersWidget';
 import SleepStagesWidget from './SleepStagesWidget';
 import MedicalConditionsWidget from './MedicalConditionsWidget';
+import AIAssistantWidget from './AIAssistantWidget';
 
 export default function Dashboard() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -179,10 +180,7 @@ export default function Dashboard() {
             <div className="dashboard-section">
               <FatigueWidget probability={fatigueProbability} />
               <ActivityWidget data={activityData} />
-              <div className="widget ai-assistant-widget">
-                <h3><FontAwesomeIcon icon={faRobot} /> Assistent IA</h3>
-                <p>Pròximament...</p>
-              </div>
+              <AIAssistantWidget fitbitData={fitbitData} />
             </div>
 
             {/* Column 2: RMSSD, Activity Charts, Biomarkers */}

--- a/frontend/src/hooks/useRecomendation.js
+++ b/frontend/src/hooks/useRecomendation.js
@@ -1,10 +1,15 @@
 
 import { useState } from "react";
+
 export default function useRecommendation() {
+  // Estat de la recomanació generada
   const [rec, setRec] = useState(null);
+  // Indicador de càrrega
   const [loading, setLoading] = useState(false);
+  // Missatge d'error si la petició falla
   const [error, setError] = useState(null);
 
+  // Funció per demanar la recomanació al backend
   const generate = async (data) => {
     setLoading(true);
     try {


### PR DESCRIPTION
## Summary
- connect frontend "Assistent IA" widget with backend
- add hook comments in català
- enable `/recommend` endpoint in FastAPI backend

## Testing
- `npm run build`
- `python -m py_compile backend/ai.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68482fea27dc8331998a6cf502e126d0