### PR TITLE
Afegir informes IA amb emmagatzematge i modal

### DIFF
--- a/frontend/src/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/components/Dashboard/Dashboard.jsx
@@ -13,10 +13,12 @@ import BiomarkersWidget from './BiomarkersWidget';
 import SleepStagesWidget from './SleepStagesWidget';
 import MedicalConditionsWidget from './MedicalConditionsWidget';
 import AIAssistantWidget from './AIAssistantWidget';
+import IaReportsModal from '../IaReportsModal';
 
 export default function Dashboard() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+  const [isReportsModalOpen, setIsReportsModalOpen] = useState(false);
   const [currentDate, setCurrentDate] = useState('');
   const { data: fitbitData, loading: isLoading, error } = useFitbitData();
   const { data: profileData, refetch: refetchProfile } = useUserProfile();
@@ -104,7 +106,7 @@ export default function Dashboard() {
 
   const navItems = [
     { id: 'dashboard', icon: faTachometerAlt, text: 'Tauler de Control', active: true },
-    { id: 'assistant', icon: faFileAlt, text: 'Informes IA', active: false },
+    { id: 'assistant', icon: faFileAlt, text: 'Informes IA', active: false, onClick: () => setIsReportsModalOpen(true) },
     { id: 'profile', icon: faUser, text: 'Perfil', active: false, onClick: () => setIsProfileModalOpen(true) },
   ];
 
@@ -213,6 +215,10 @@ export default function Dashboard() {
         onClose={() => setIsProfileModalOpen(false)}
         userData={profileData}
         onProfileUpdate={refetchProfile}
+      />
+      <IaReportsModal
+        isOpen={isReportsModalOpen}
+        onClose={() => setIsReportsModalOpen(false)}
       />
     </div>
   );

--- a/frontend/src/components/IaReportsModal.css
+++ b/frontend/src/components/IaReportsModal.css
@@ -1,0 +1,77 @@
+.ia-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+}
+
+.ia-modal-container {
+  background: #1A1A1A;
+  border: 1px solid #333333;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+  color: #F5F5F5;
+  font-family: 'Inter', sans-serif;
+}
+
+.ia-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #333333;
+}
+
+.ia-close-button {
+  background: none;
+  border: 1px solid #333333;
+  font-size: 1.1rem;
+  color: #758680;
+  cursor: pointer;
+  padding: 0.4rem;
+  border-radius: 50%;
+  transition: all 0.2s;
+}
+
+.ia-close-button:hover {
+  background-color: #333333;
+  color: #F5F5F5;
+  border-color: #D4FF58;
+}
+
+.ia-modal-body {
+  padding: 1rem 1.25rem;
+}
+
+.reports-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.report-item {
+  border-bottom: 1px solid #333333;
+  padding-bottom: 0.75rem;
+}
+
+.report-date {
+  font-size: 0.8rem;
+  color: #758680;
+  margin-bottom: 0.3rem;
+}
+
+.report-text {
+  white-space: pre-wrap;
+  color: #F5F5F5;
+}

--- a/frontend/src/components/IaReportsModal.jsx
+++ b/frontend/src/components/IaReportsModal.jsx
@@ -1,0 +1,48 @@
+// Modal per mostrar els darrers informes generats per la IA
+import React from 'react';
+import './IaReportsModal.css';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes, faRobot } from '@fortawesome/free-solid-svg-icons';
+import useIaReports from '../hooks/useIaReports';
+
+const IaReportsModal = ({ isOpen, onClose }) => {
+  // Obté els informes quan el modal està obert
+  const { data: reports, loading, error } = useIaReports(isOpen);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="ia-modal-overlay">
+      <div className="ia-modal-container">
+        <div className="ia-modal-header">
+          <h2><FontAwesomeIcon icon={faRobot} /> Informes IA</h2>
+          <button onClick={onClose} className="ia-close-button" aria-label="Tancar">
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
+        <div className="ia-modal-body">
+          {loading && <p>Carregant informes...</p>}
+          {error && <p>Error: {error.message}</p>}
+          {!loading && !error && reports.length === 0 && (
+            <p>Encara no hi ha informes.</p>
+          )}
+          {!loading && !error && reports.length > 0 && (
+            <ul className="reports-list">
+              {reports.map((r, idx) => (
+                // Cada element mostra la data i el text de l'informe
+                <li key={idx} className="report-item">
+                  <div className="report-date">
+                    {new Date(r.date).toLocaleString('ca-ES')}
+                  </div>
+                  <div className="report-text">{r.text}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default IaReportsModal;

--- a/frontend/src/hooks/useIaReports.js
+++ b/frontend/src/hooks/useIaReports.js
@@ -1,0 +1,36 @@
+import { useState, useEffect } from "react";
+
+// Hook per obtenir els informes de la IA
+export default function useIaReports(isOpen) {
+  const [data, setData] = useState([]); // Informes rebuts
+  const [loading, setLoading] = useState(true); // Estat de càrrega
+  const [error, setError] = useState(null); // Possible error
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let mounted = true;
+
+    const fetchReports = async () => {
+      try {
+        const r = await fetch("http://localhost:8000/ia-reports");
+        const j = await r.json();
+        if (!r.ok) throw new Error(j.detail || r.statusText);
+        if (mounted) {
+          setData(j);
+          setError(null);
+        }
+      } catch (e) {
+        if (mounted) setError(e);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+
+    fetchReports();
+    return () => {
+      mounted = false;
+    };
+  }, [isOpen]);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
## Summary
- crea una nova taula `informes_ia` per desar recomanacions
- desa automàticament cada recomanació a la BD
- nou endpoint `/ia-reports` per consultar els darrers informes
- afegeix hook `useIaReports` i modal `IaReportsModal` al frontend
- mostra els informes des de la barra lateral del dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cc9b9c288331a08de190bc0f1da5