### PR TITLE
Afegit pop-up de pla d'entrenament

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,8 +9,10 @@ from fitbit_fetch import (
     save_user_profile,
     save_ia_report,
     fetch_ia_reports,
+    update_latest_training_plan,
+    fetch_latest_training_plan,
 )
-from ai import get_recommendation
+from ai import get_recommendation, get_pla_estructurat
 
 import numpy as np
 import logging
@@ -132,6 +134,30 @@ def recommend(payload: dict):
         log.exception("/recommend failed")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
+
+@app.post("/training-plan")
+def training_plan(payload: dict):
+    """Genera i desa el pla d'entrenament estructurat."""
+    try:
+        text = get_pla_estructurat(
+            payload.get("fitbit", {}), payload.get("recommendation", "")
+        )
+        update_latest_training_plan(text, user_id=payload.get("user_id", "default"))
+        return {"text": text}
+    except Exception as exc:
+        log.exception("/training-plan failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/training-plan")
+def get_training_plan(user_id: str = "default"):
+    """Recupera l'últim pla d'entrenament de la BD."""
+    try:
+        text = fetch_latest_training_plan(user_id=user_id)
+        return {"text": text}
+    except Exception as exc:
+        log.exception("/training-plan GET failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 @app.get("/ia-reports")
 def ia_reports(limit: int = 10, user_id: str = "CJK8XS"): # Aqui poso el meu user ID, en un futur user id seria un parametre que s'extreuris de la taula de user profile

--- a/frontend/src/components/Dashboard/AIAssistantWidget.jsx
+++ b/frontend/src/components/Dashboard/AIAssistantWidget.jsx
@@ -4,10 +4,12 @@ import { faRobot, faLightbulb, faDumbbell } from '@fortawesome/free-solid-svg-ic
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import useRecommendation from '../../hooks/useRecomendation';
+import useTrainingPlan from '../../hooks/useTrainingPlan';
 import './AIAssistantWidget.css'; // Importa el nou CSS
 
-export default function AIAssistantWidget({ fitbitData }) {
+export default function AIAssistantWidget({ fitbitData, onPlanReady }) {
   const { rec, loading, error, generate } = useRecommendation();
+  const { generate: generatePlan, loading: planLoading } = useTrainingPlan();
   const [showRecommendation, setShowRecommendation] = useState(false);
 
   const handleRecommend = () => {
@@ -44,9 +46,19 @@ export default function AIAssistantWidget({ fitbitData }) {
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{rec}</ReactMarkdown>
                   <p>Vols generar / modificar el teu pla d'entrenament?</p>
                   <div className="widget-actions">
-                    <button className="btn btn-secondary" disabled>
+                    <button
+                      className="btn btn-secondary"
+                      onClick={async () => {
+                        await generatePlan({
+                          fitbit: fitbitData || {},
+                          recommendation: rec,
+                        });
+                        if (onPlanReady) onPlanReady();
+                      }}
+                      disabled={planLoading}
+                    >
                       <FontAwesomeIcon icon={faDumbbell} className="btn-icon" />
-                      Pla d'Entrenament (Pròximament...)
+                      Pla d'Entrenament
                     </button>
                   </div>
                 </>

--- a/frontend/src/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/components/Dashboard/Dashboard.jsx
@@ -14,11 +14,13 @@ import SleepStagesWidget from './SleepStagesWidget';
 import MedicalConditionsWidget from './MedicalConditionsWidget';
 import AIAssistantWidget from './AIAssistantWidget';
 import IaReportsModal from '../IaReportsModal';
+import TrainingPlanModal from '../TrainingPlanModal';
 
 export default function Dashboard() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
   const [isReportsModalOpen, setIsReportsModalOpen] = useState(false);
+  const [isPlanModalOpen, setIsPlanModalOpen] = useState(false);
   const [currentDate, setCurrentDate] = useState('');
   const { data: fitbitData, loading: isLoading, error } = useFitbitData();
   const { data: profileData, refetch: refetchProfile } = useUserProfile();
@@ -107,7 +109,7 @@ export default function Dashboard() {
   const navItems = [
     { id: 'dashboard', icon: faTachometerAlt, text: 'Tauler de Control', active: true },
     { id: 'assistant', icon: faFileAlt, text: 'Informes IA', active: false, onClick: () => setIsReportsModalOpen(true) },
-    { id: 'plan', icon: faDumbbell, text: 'Pla d\'Entrenament', active: false },
+    { id: 'plan', icon: faDumbbell, text: "Pla d'Entrenament", active: false, onClick: () => setIsPlanModalOpen(true) },
     { id: 'profile', icon: faUser, text: 'Perfil', active: false, onClick: () => setIsProfileModalOpen(true) },
   ];
 
@@ -185,7 +187,10 @@ export default function Dashboard() {
             <div className="dashboard-section">
               <FatigueWidget probability={fatigueProbability} />
               <ActivityWidget data={activityData} />
-              <AIAssistantWidget fitbitData={fitbitData} />
+              <AIAssistantWidget
+                fitbitData={fitbitData}
+                onPlanReady={() => setIsPlanModalOpen(true)}
+              />
             </div>
 
             {/* Column 2: RMSSD, Activity Charts, Biomarkers */}
@@ -222,6 +227,10 @@ export default function Dashboard() {
       <IaReportsModal
         isOpen={isReportsModalOpen}
         onClose={() => setIsReportsModalOpen(false)}
+      />
+      <TrainingPlanModal
+        isOpen={isPlanModalOpen}
+        onClose={() => setIsPlanModalOpen(false)}
       />
     </div>
   );

--- a/frontend/src/components/TrainingPlanModal.css
+++ b/frontend/src/components/TrainingPlanModal.css
@@ -1,0 +1,287 @@
+/* TrainingPlanModal.css */
+
+.plan-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+}
+
+.plan-modal-container {
+  background: #1A1A1A; /* Fondo de tarjetas */
+  border: 1px solid #333333; /* Bordes */
+  border-radius: 12px;
+  width: 90%;
+  max-width: 800px; /* Increased width for better report reading */
+  max-height: 90vh;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+  color: #F5F5F5; /* Texto principal */
+  font-family: 'Inter', sans-serif;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Barra de desplaçament per al contenidor principal */
+.plan-modal-container::-webkit-scrollbar {
+  width: 8px;
+}
+.plan-modal-container::-webkit-scrollbar-track {
+  background: #1A1A1A;
+  border-radius: 4px;
+}
+.plan-modal-container::-webkit-scrollbar-thumb {
+  background: #333333;
+  border-radius: 4px;
+}
+.plan-modal-container::-webkit-scrollbar-thumb:hover {
+  background: #444444;
+}
+
+.plan-modal-container {
+  scrollbar-width: thin;
+  scrollbar-color: #333333 #1A1A1A;
+}
+
+.plan-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #333333;
+  flex-shrink: 0;
+}
+
+.plan-modal-header h2 {
+    color: #F5F5F5;
+}
+
+.plan-close-button {
+  background: none;
+  border: 1px solid #333333;
+  font-size: 1.1rem;
+  color: #758680; /* Texto secundario */
+  cursor: pointer;
+  padding: 0.4rem;
+  border-radius: 50%;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.plan-close-button:hover {
+  background-color: #333333;
+  color: #D4FF58; /* Color de acento */
+  border-color: #D4FF58;
+}
+
+.plan-modal-body {
+  padding: 0;
+  overflow-y: auto;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.7;
+}
+
+/* Barra de desplaçament personalitzada del cos del modal */
+.plan-modal-body::-webkit-scrollbar {
+  width: 8px;
+}
+.plan-modal-body::-webkit-scrollbar-track {
+  background: #1A1A1A;
+  border-radius: 4px;
+}
+.plan-modal-body::-webkit-scrollbar-thumb {
+  background: #333333;
+  border-radius: 4px;
+}
+.plan-modal-body::-webkit-scrollbar-thumb:hover {
+  background: #444444;
+}
+
+.plan-modal-body {
+  scrollbar-width: thin;
+  scrollbar-color: #333333 #1A1A1A;
+}
+
+.plan-content {
+  list-style: none;
+  padding: 1.5rem;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.plan-item {
+  border: 1px solid #333333;
+  border-radius: 8px;
+  padding: 1.5rem;
+  background-color: #000000; /* Fondo Principal */
+}
+
+.plan-date {
+  font-size: 0.9rem;
+  color: #758680; /* Texto secundario */
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #333333;
+  padding-bottom: 0.5rem;
+}
+
+.plan-text {
+  color: #F5F5F5; /* Texto principal */
+}
+
+/* Estat tancat i obert dels textos dels informes */
+.plan-text.collapsed {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.plan-text.expanded {
+  max-height: none;
+}
+
+/* Barra per a cada text d'informe */
+.plan-text.collapsed::-webkit-scrollbar,
+.plan-text.expanded::-webkit-scrollbar {
+  width: 8px;
+}
+.plan-text.collapsed::-webkit-scrollbar-track,
+.plan-text.expanded::-webkit-scrollbar-track {
+  background: #1A1A1A;
+  border-radius: 4px;
+}
+.plan-text.collapsed::-webkit-scrollbar-thumb,
+.plan-text.expanded::-webkit-scrollbar-thumb {
+  background: #333333;
+  border-radius: 4px;
+}
+.plan-text.collapsed::-webkit-scrollbar-thumb:hover,
+.plan-text.expanded::-webkit-scrollbar-thumb:hover {
+  background: #444444;
+}
+
+.plan-text.collapsed,
+.plan-text.expanded {
+  scrollbar-width: thin;
+  scrollbar-color: #333333 #1A1A1A;
+}
+
+/* Estils per al contingut Markdown dins de .plan-text */
+.plan-text h1,
+.plan-text h2,
+.plan-text h3 {
+  color: #D4FF58; /* Color de acento */
+  border-bottom: 1px solid #333333;
+  padding-bottom: 10px;
+  margin-top: 24px;
+  margin-bottom: 16px;
+}
+
+.plan-text h1 { font-size: 2em; }
+.plan-text h2 { font-size: 1.7em; }
+.plan-text h3 { font-size: 1.4em; }
+
+.plan-text p { margin-bottom: 16px; }
+
+.plan-text a {
+  color: #D4FF58;
+  text-decoration: none;
+  transition: text-decoration 0.3s ease;
+}
+
+.plan-text a:hover { text-decoration: underline; }
+
+.plan-text ul,
+.plan-text ol {
+  padding-left: 20px;
+  margin-bottom: 16px;
+}
+
+.plan-text li { margin-bottom: 8px; }
+
+.plan-text blockquote {
+  border-left: 4px solid #D4FF58;
+  padding-left: 16px;
+  margin: 0 0 16px 0;
+  color: #758680; /* Texto secundario */
+  font-style: italic;
+}
+
+.plan-text code {
+  background-color: #252525;
+  color: #F5F5F5;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-family: 'Courier New', Courier, monospace;
+}
+
+.plan-text pre {
+  background-color: #0d0d0d;
+  padding: 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid #333333;
+}
+
+.plan-text pre code {
+  padding: 0;
+  background: none;
+  border: none;
+}
+
+.plan-text table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 16px;
+}
+
+.plan-text th,
+.plan-text td {
+  border: 1px solid #333333;
+  padding: 12px;
+  text-align: left;
+}
+
+.plan-text th {
+  background-color: #333333;
+  color: #D4FF58;
+}
+
+.plan-text tr:nth-child(even) {
+  background-color: #252525;
+}
+
+.modal-info-text {
+  color: #758680; /* Texto secundario */
+  font-style: italic;
+  text-align: center;
+  padding: 2rem;
+}
+
+.modal-error-text {
+  color: #D4FF58; /* Color de acento */
+  font-weight: bold;
+  text-align: center;
+  padding: 2rem;
+}
+
+/* Botó per mostrar o amagar el text complet */
+.toggle-report {
+  margin-top: 0.5rem;
+  background: none;
+  border: none;
+  color: #D4FF58;
+  cursor: pointer;
+  font-size: 0.85rem;
+  text-align: right;
+}
+
+.toggle-report:hover {
+  text-decoration: underline;
+}
+

--- a/frontend/src/components/TrainingPlanModal.jsx
+++ b/frontend/src/components/TrainingPlanModal.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import './TrainingPlanModal.css';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes, faDumbbell } from '@fortawesome/free-solid-svg-icons';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import useTrainingPlan from '../hooks/useTrainingPlan';
+
+const TrainingPlanModal = ({ isOpen, onClose }) => {
+  const { data: plan, loading, error } = useTrainingPlan(isOpen);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="plan-modal-overlay" onClick={onClose}>
+      <div className="plan-modal-container" onClick={(e) => e.stopPropagation()}>
+        <div className="plan-modal-header">
+          <h2><FontAwesomeIcon icon={faDumbbell} /> Pla d'Entrenament</h2>
+          <button onClick={onClose} className="plan-close-button" aria-label="Tancar">
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
+        <div className="plan-modal-body">
+          {loading && <p className="modal-info-text">Carregant pla...</p>}
+          {error && <p className="modal-error-text">Error: {error.message}</p>}
+          {!loading && !error && plan && (
+            <div className="plan-text">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{plan}</ReactMarkdown>
+            </div>
+          )}
+          {!loading && !error && !plan && (
+            <p className="modal-info-text">Encara no hi ha cap pla.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TrainingPlanModal;
+

--- a/frontend/src/hooks/useTrainingPlan.js
+++ b/frontend/src/hooks/useTrainingPlan.js
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+
+export default function useTrainingPlan(isOpen = false) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchPlan = async () => {
+    setLoading(true);
+    try {
+      const r = await fetch("http://localhost:8000/training-plan");
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.detail || r.statusText);
+      setData(j.text);
+      setError(null);
+    } catch (e) {
+      setError(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const generate = async (payload) => {
+    setLoading(true);
+    try {
+      const r = await fetch("http://localhost:8000/training-plan", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.detail || r.statusText);
+      setData(j.text);
+      setError(null);
+    } catch (e) {
+      setError(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchPlan();
+    }
+  }, [isOpen]);
+
+  return { data, loading, error, generate, refetch: fetchPlan };
+}
+


### PR DESCRIPTION
## Summary
- crea nova columna `training_plan` a `informes_ia`
- guarda i actualitza plans d'entrenament a la BD
- endpoints `/training-plan` per generar i recuperar l'últim pla
- hook i modal per mostrar el pla a la UI
- integra el botó de pla d'entrenament a l'assistent i a la barra lateral

## Testing
- `python3 -m py_compile backend/fitbit_fetch.py backend/main.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684996bdfebc8331a3f3417624b76757