### PR TITLE
Adjust dashboard layout

### DIFF
--- a/frontend/src/components/Dashboard/ActivityWidget.css
+++ b/frontend/src/components/Dashboard/ActivityWidget.css
@@ -57,24 +57,27 @@
 }
 
 /* Chart Tabs Styling */
+
+/* Pestanyes per als gràfics */
 .chart-tabs {
     display: flex;
-    justify-content: center; /* Center tabs if there are few, or use flex-start if many */
-    margin-bottom: 15px; /* Space below tabs */
-    border-bottom: 1px solid var(--border-color); /* Optional: a subtle line under the tabs container */
+    justify-content: center; /* Centrem les pestanyes */
+    margin-bottom: 15px;
+    border-bottom: 1px solid var(--border-color);
+    flex-shrink: 0;
 }
 
 .tab-button {
-    padding: 10px 20px;
-    font-size: 0.9rem;
+    padding: 8px 16px;
+    font-size: 0.85rem;
     font-weight: 500;
     color: var(--text-secondary);
     background-color: transparent;
     border: none;
-    border-bottom: 3px solid transparent; /* For active indicator */
+    border-bottom: 2px solid transparent; /* Indicador actiu */
     cursor: pointer;
     transition: color 0.3s ease, border-bottom-color 0.3s ease;
-    margin: 0 5px; /* Space between tab buttons */
+    margin: 0 4px;
     text-transform: uppercase;
 }
 

--- a/frontend/src/components/Dashboard/ActivityWidget.jsx
+++ b/frontend/src/components/Dashboard/ActivityWidget.jsx
@@ -42,7 +42,8 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
             typeof intensityData.intense === 'undefined')) {
             return (
                 <div className="widget activity-widget chart-widget">
-                    <div className="widget-content" style={{padding: '15px', display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '250px' }}>
+                {/* Contenidor amb alçada major per donar espai al gràfic */}
+                <div className="widget-content" style={{padding: '15px', display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '300px' }}>
                         <p>Carregant dades d'intensitat...</p>
                     </div>
                 </div>
@@ -56,7 +57,8 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
             typeof hrZonesData.inZone3 === 'undefined')) {
             return (
                 <div className="widget activity-widget chart-widget">
-                     <div className="widget-content" style={{padding: '15px', display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '250px' }}>
+                     {/* Contenidor amb alçada major per donar espai al gràfic */}
+                     <div className="widget-content" style={{padding: '15px', display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '300px' }}>
                         <p>Carregant dades de zones FC...</p>
                     </div>
                 </div>
@@ -162,8 +164,9 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
             ],
         };
         
+        // Més espai vertical perquè el gràfic es vegi millor
         return (
-            <div className="widget-content" style={{padding: '15px', display: 'flex', flexDirection: 'column', flexGrow: 1, minHeight: '250px' }}>
+            <div className="widget-content" style={{padding: '15px', display: 'flex', flexDirection: 'column', flexGrow: 1, minHeight: '300px' }}>
                 <div className="chart-tabs">
                     <button 
                         className={`tab-button ${activeTab === 'activity' ? 'active' : ''}`} 

--- a/frontend/src/components/Dashboard/Dashboard.css
+++ b/frontend/src/components/Dashboard/Dashboard.css
@@ -25,7 +25,7 @@
 
 /* --- COLUMNA CENTRAL --- */
 .rmssd-widget {
-    flex: 0 0 170px; /* Ajustat per alçada del contingut */
+    flex: 0 0 130px; /* Reduïm alçada per guanyar espai als gràfics */
     /* min-height: 160px; No cal si flex-basis controla l'alçada */
 }
 
@@ -281,10 +281,10 @@
     flex-grow: 1;
     display: flex;
     flex-direction: column;
-    min-height: 100vh;
+    height: 100vh; /* Evitem desplaçament vertical */
     margin-left: var(--sidebar-width-collapsed);
     transition: margin-left 0.3s ease-in-out;
-    overflow-y: auto;
+    overflow: hidden;
     width: calc(100% - var(--sidebar-width-collapsed));
 }
 
@@ -388,9 +388,9 @@
 .fatigue-indicator-container {
     position: relative;
     width: 100%;
-    max-width: 300px; /* Slightly reduced max-width */
-    height: 300px; /* Reduced height */
-    margin: 0 auto 5px; /* Reduced bottom margin */
+    max-width: 250px; /* Indicador més petit */
+    height: 250px; /* Alçada reduïda */
+    margin: 0 auto 5px; /* Mantenim un petit marge inferior */
     display: flex;
     align-items: center;
     justify-content: center;
@@ -462,7 +462,10 @@
     margin-top: 4px; /* Pequeño ajuste para espaciado */
 }
 
-/* Styles for AI Assistant Widget */
+/* Estils per al widget d'assistent IA */
+.ai-assistant-widget {
+    flex-grow: 1; /* Ocupa l'espai restant de la columna */
+}
 .ai-assistant-widget .widget-content {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- reduce RMSSD widget height
- resize fatigue indicator and let AI assistant fill remaining space
- adjust main content to avoid vertical scroll
- shrink activity graph tabs and allocate more height to charts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b477ab7648331ad920cc0a6a48541