### PR TITLE
Millores al dashboard

### DIFF
--- a/frontend/src/components/Dashboard/AIAssistantWidget.css
+++ b/frontend/src/components/Dashboard/AIAssistantWidget.css
@@ -6,14 +6,14 @@
 }
 
 .ai-assistant-widget .recommendation-area {
-  background-color: #0d0d0d; /* Slightly lighter than pure black for depth */
+  background-color: #0d0d0d; /* Fons lleugerament més clar */
   border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 1.2rem;
   margin-top: 1rem;
   color: var(--text-main);
   animation: fadeIn 0.5s ease-in-out;
-  max-height: 200px;
+  flex-grow: 1; /* Emplenem l'alçada disponible del widget */
   overflow-y: auto;
 }
 

--- a/frontend/src/components/Dashboard/ActivityWidget.jsx
+++ b/frontend/src/components/Dashboard/ActivityWidget.jsx
@@ -22,12 +22,11 @@ ChartJS.register(
   Legend
 );
 
-// Helper function to format minutes into a more readable string (e.g., "1h 30m" or "45m")
-const formatMinutesToHoursAndMinutes = (totalMinutes) => {
-    if (totalMinutes === undefined || totalMinutes === null || totalMinutes < 0) return "0m";
-    const hours = Math.floor(totalMinutes / 60);
-    const minutes = Math.round(totalMinutes % 60);
-    return `${hours > 0 ? `${hours}h ` : ''}${minutes}m`;
+// Conversió de minuts a hores arrodonides per mostrar a l'eix Y
+const formatMinutesToHours = (totalMinutes) => {
+    if (totalMinutes === undefined || totalMinutes === null || totalMinutes < 0) return "0h";
+    const hours = Math.round(totalMinutes / 60);
+    return `${hours}h`;
 };
 
 const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
@@ -80,7 +79,7 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
                         color: '#758680', // --text-secondary
                         padding: 10,
                         callback: function(value) {
-                            return formatMinutesToHoursAndMinutes(value);
+                            return formatMinutesToHours(value);
                         }
                     },
                 },
@@ -110,7 +109,7 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
                         label: function (context) {
                             let label = context.dataset.label || '';
                             if (context.parsed.y !== null) {
-                                label = `${context.label}: ${formatMinutesToHoursAndMinutes(context.parsed.y)}`;
+                                label = `${context.label}: ${formatMinutesToHours(context.parsed.y)}`;
                             }
                             return label;
                         },

--- a/frontend/src/components/Dashboard/Dashboard.css
+++ b/frontend/src/components/Dashboard/Dashboard.css
@@ -281,7 +281,7 @@
     flex-grow: 1;
     display: flex;
     flex-direction: column;
-    height: 100vh; /* Evitem desplaçament vertical */
+    height: calc(100vh - 8px); /* L'alçada lleugerament reduïda evita la barra vertical */
     margin-left: var(--sidebar-width-collapsed);
     transition: margin-left 0.3s ease-in-out;
     overflow: hidden;
@@ -341,11 +341,12 @@
 
 .dashboard-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); /* Responsive columns */
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); /* Columnes adaptatives */
     gap: 20px;
     padding: 25px;
     flex-grow: 1;
-    overflow-y: auto; /* If grid itself needs to scroll, though sections handle it */
+    height: 100%; /* Permet que les columnes ocupin tota l'alçada disponible */
+    overflow-y: auto;
 }
 
 .dashboard-section {
@@ -360,10 +361,20 @@
 
 .dashboard-main-content > .dashboard-section:nth-child(2) {
     flex-basis: 20%;
+    height: 100%; /* Assegurem que la columna central aprofiti l'alçada */
+    min-height: 0;
 }
 
 .dashboard-main-content > .dashboard-section:nth-child(3) {
     flex-basis: 40%;
+}
+
+/* El widget de gràfics ocupa l'espai restant de la columna central */
+.dashboard-main-content > .dashboard-section:nth-child(2) .activity-charts-widget {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
 }
 /* Misplaced comments and orphaned closing brace removed to fix syntax error */
 


### PR DESCRIPTION
## Summary
- ajusta l'alçada del `dashboard-main-content` per evitar scroll vertical
- fa que la columna central i el widget de gràfics aprofitin tota l'alçada
- simplifica les unitats de l'eix Y mostrant hores als gràfics d'activitat
- permet que el text de l'assistent IA ompli tot el seu widget

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b5c3095788331b80e8e79187b81b2