### PR TITLE
Automate weekly plan after new macrocycle

### DIFF
--- a/frontend/src/hooks/useRecomendation.js
+++ b/frontend/src/hooks/useRecomendation.js
@@ -20,6 +20,7 @@ export default function useRecommendation() {
       const j = await r.json();
       if (!r.ok) throw new Error(j.detail || r.statusText);
       setRec(j.text);
+      return j.text; // Retorna la recomanació obtinguda
     } catch (e) {
       setError(e.message);
     } finally {


### PR DESCRIPTION
## Summary
- trigger daily recommendation and weekly plan generation after creating a new macrocycle
- allow `useRecommendation` hook to return the generated text

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851b216e5648331b774a2392ab5784d