### PR TITLE
Implementació de tendències setmanals

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from fitbit_fetch import (
     fetch_latest_training_plan,
     save_macrocycle,
     fetch_latest_macrocycle,
+    fetch_weekly_data,
 )
 from ai import get_recommendation, get_pla_estructurat, generate_macros
 
@@ -100,6 +101,16 @@ def fitbit_data():
         return JSONResponse(content=payload)
     except Exception as exc:
         log.exception("/fitbit-data failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/fitbit-weekly")
+def fitbit_weekly():
+    try:
+        data = fetch_weekly_data()
+        return JSONResponse(content=jsonable_encoder(data))
+    except Exception as exc:
+        log.exception("/fitbit-weekly failed")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 @app.get("/user-profile")

--- a/frontend/src/components/Dashboard/ActivityWidget.css
+++ b/frontend/src/components/Dashboard/ActivityWidget.css
@@ -91,3 +91,9 @@
     border-bottom-color: var(--accent-color);
 }
 
+.trend-chart-container {
+    position: relative;
+    width: 100%;
+    height: 220px;
+}
+

--- a/frontend/src/components/Dashboard/ActivityWidget.jsx
+++ b/frontend/src/components/Dashboard/ActivityWidget.jsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
-import { Bar } from 'react-chartjs-2';
+import { Bar, Line } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
   BarElement,
+  PointElement,
+  LineElement,
   Title,
   Tooltip,
   Legend,
@@ -17,6 +19,8 @@ ChartJS.register(
   CategoryScale,
   LinearScale,
   BarElement,
+  PointElement,
+  LineElement,
   Title,
   Tooltip,
   Legend
@@ -32,7 +36,7 @@ const formatMinutesToHoursAndMinutes = (totalMinutes) => {
 
 };
 
-const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
+const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = [], trendIntensity = [], trendHr = [] }) => {
     const [activeTab, setActiveTab] = useState('activity'); // 'activity', 'hrZones', or 'tendencia'
 
     if (type === 'chartTabs') {
@@ -197,8 +201,37 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
                         <Bar options={commonChartOptions} data={hrZonesChartData} />
                     )}
                     {activeTab === 'tendencia' && (
-                        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-                            <p>Pròximament...</p>
+                        <div className="trend-chart-container">
+                        <Line
+                            options={{
+                                responsive: true,
+                                maintainAspectRatio: false,
+                                scales: {
+                                    y: { beginAtZero: true, grid: { color: 'rgba(117,134,128,0.2)', drawBorder: false } },
+                                    x: { grid: { display: false }, ticks: { color: '#F5F5F5' } }
+                                },
+                                plugins: { legend: { display: false } }
+                            }}
+                            data={{
+                                labels: trendLabels,
+                                datasets: [
+                                    {
+                                        label: 'Minuts actius',
+                                        data: trendIntensity,
+                                        borderColor: '#D4FF58',
+                                        backgroundColor: 'rgba(212,255,88,0.3)',
+                                        tension: 0.3,
+                                    },
+                                    {
+                                        label: 'Zones 2-3',
+                                        data: trendHr,
+                                        borderColor: '#A5A5A5',
+                                        backgroundColor: 'rgba(165,165,165,0.3)',
+                                        tension: 0.3,
+                                    }
+                                ]
+                            }}
+                        />
                         </div>
                     )}
                 </div>

--- a/frontend/src/components/Dashboard/SleepStagesWidget.css
+++ b/frontend/src/components/Dashboard/SleepStagesWidget.css
@@ -235,3 +235,9 @@
     font-size: 0.9rem;
 }
 
+.sleep-trend-chart {
+    position: relative;
+    width: 100%;
+    height: 200px;
+}
+

--- a/frontend/src/components/Dashboard/SleepStagesWidget.jsx
+++ b/frontend/src/components/Dashboard/SleepStagesWidget.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { Doughnut } from 'react-chartjs-2';
-import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+import { Doughnut, Line } from 'react-chartjs-2';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement } from 'chart.js';
 import './SleepStagesWidget.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMoon, faClock, faBed, faPercent, faEye } from '@fortawesome/free-solid-svg-icons';
 
-ChartJS.register(ArcElement, Tooltip, Legend);
+ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement);
 
 // Format numeric
 function formatMinutesToHoursAndMinutes(totalMinutes) {
@@ -15,7 +15,7 @@ function formatMinutesToHoursAndMinutes(totalMinutes) {
     return `${hours > 0 ? hours + 'h ' : ''}${minutes}m`;
 }
 
-const SleepStagesWidget = ({ stagesData, metricsData }) => {
+const SleepStagesWidget = ({ stagesData, metricsData, trendData = [], trendLabels = [] }) => {
     const [activeTab, setActiveTab] = useState('fases'); // 'fases', 'metriques', 'tendencies'
 
     // Default to an empty array if stagesData is not provided or not an array
@@ -163,8 +163,29 @@ const SleepStagesWidget = ({ stagesData, metricsData }) => {
                 )}
 
                 {activeTab === 'tendencies' && (
-                    <div className="sleep-tab-content active" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '200px' }}>
-                        <p>Pròximament...</p>
+                    <div className="sleep-tab-content active">
+                        <div className="sleep-trend-chart">
+                            <Line
+                                options={{
+                                    responsive: true,
+                                    maintainAspectRatio: false,
+                                    scales: {
+                                        y: { beginAtZero: true, grid: { color: 'rgba(117,134,128,0.2)', drawBorder: false } },
+                                        x: { grid: { display: false }, ticks: { color: '#F5F5F5' } }
+                                    },
+                                    plugins: { legend: { display: false } }
+                                }}
+                                data={{
+                                    labels: trendLabels,
+                                    datasets: [
+                                        { label: 'Profund', data: trendData.map(d => d.deep), borderColor: 'var(--accent-color)', backgroundColor: 'rgba(212,255,88,0.3)', tension: 0.3 },
+                                        { label: 'Lleuger', data: trendData.map(d => d.light), borderColor: 'var(--text-secondary)', backgroundColor: 'rgba(117,134,128,0.3)', tension: 0.3 },
+                                        { label: 'REM', data: trendData.map(d => d.rem), borderColor: 'var(--text-primary)', backgroundColor: 'rgba(245,245,245,0.3)', tension: 0.3 },
+                                        { label: 'Despert', data: trendData.map(d => d.awake), borderColor: 'var(--border-color)', backgroundColor: 'rgba(51,51,51,0.3)', tension: 0.3 }
+                                    ]
+                                }}
+                            />
+                        </div>
                     </div>
                 )}
             </div>

--- a/frontend/src/hooks/useWeeklyData.js
+++ b/frontend/src/hooks/useWeeklyData.js
@@ -1,0 +1,36 @@
+import { useState, useEffect } from "react";
+
+// Hook per obtenir les dades de la darrera setmana
+export default function useWeeklyData() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const fetchWeek = async () => {
+      try {
+        const r = await fetch("http://localhost:8000/fitbit-weekly");
+        const j = await r.json();
+        if (!r.ok) throw new Error(j.detail || r.statusText);
+        if (mounted) {
+          setData(j);
+          setError(null);
+        }
+      } catch (e) {
+        if (mounted) setError(e);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+
+    fetchWeek();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { data, loading, error };
+}
+


### PR DESCRIPTION
## Resum
- taula `fitbit_last_week` i endpoint `/fitbit-weekly`
- hook `useWeeklyData` per consumir l'endpoint
- gràfic de tendència a `ActivityWidget` i `SleepStagesWidget`
- estils per contenidors de tendència

## Testing
- `npm --prefix frontend run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6851d35eb2588331951a8d6fad88a9ee