### PR TITLE
Implement weekly trend data

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from fitbit_fetch import (
     save_user_profile,
     save_ia_report,
     fetch_ia_reports,
+    fetch_last_seven_days,
     update_latest_training_plan,
     fetch_latest_training_plan,
     save_macrocycle,
@@ -100,6 +101,16 @@ def fitbit_data():
         return JSONResponse(content=payload)
     except Exception as exc:
         log.exception("/fitbit-data failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/fitbit-trends")
+def fitbit_trends():
+    try:
+        payload = fetch_last_seven_days()
+        return JSONResponse(content=payload)
+    except Exception as exc:
+        log.exception("/fitbit-trends failed")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 @app.get("/user-profile")

--- a/frontend/src/components/Dashboard/ActivityWidget.jsx
+++ b/frontend/src/components/Dashboard/ActivityWidget.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
-import { Bar } from 'react-chartjs-2';
+import { Bar, Line } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
+  PointElement,
+  LineElement,
   BarElement,
   Title,
   Tooltip,
@@ -17,6 +19,8 @@ ChartJS.register(
   CategoryScale,
   LinearScale,
   BarElement,
+  LineElement,
+  PointElement,
   Title,
   Tooltip,
   Legend
@@ -32,7 +36,7 @@ const formatMinutesToHoursAndMinutes = (totalMinutes) => {
 
 };
 
-const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
+const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendData }) => {
     const [activeTab, setActiveTab] = useState('activity'); // 'activity', 'hrZones', or 'tendencia'
 
     if (type === 'chartTabs') {
@@ -168,6 +172,95 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
                 },
             ],
         };
+
+        // Dades de tendència per a les intensitats
+        const trendLabels = trendData ? trendData.map(d => d.date.slice(5)) : [];
+        const trendIntensityData = {
+            labels: trendLabels,
+            datasets: [
+                {
+                    label: 'Intensa',
+                    data: trendData ? trendData.map(d => d.very_active_minutes) : [],
+                    borderColor: '#F5F5F5',
+                    tension: 0.3
+                },
+                {
+                    label: 'Moderada',
+                    data: trendData ? trendData.map(d => d.moderately_active_minutes) : [],
+                    borderColor: '#D4FF58',
+                    tension: 0.3
+                },
+                {
+                    label: 'Lleu',
+                    data: trendData ? trendData.map(d => d.lightly_active_minutes) : [],
+                    borderColor: '#A5A5A5',
+                    tension: 0.3
+                },
+                {
+                    label: 'Sedentari',
+                    data: trendData ? trendData.map(d => d.sedentary_minutes) : [],
+                    borderColor: '#758680',
+                    tension: 0.3
+                },
+            ],
+        };
+
+        // Dades de tendència per a les zones de FC
+        const trendHrData = {
+            labels: trendLabels,
+            datasets: [
+                {
+                    label: 'Repòs',
+                    data: trendData ? trendData.map(d => d.minutes_below_default_zone_1) : [],
+                    borderColor: '#758680',
+                    tension: 0.3
+                },
+                {
+                    label: 'Zona 1',
+                    data: trendData ? trendData.map(d => d.minutes_in_default_zone_1) : [],
+                    borderColor: '#A5A5A5',
+                    tension: 0.3
+                },
+                {
+                    label: 'Zona 2',
+                    data: trendData ? trendData.map(d => d.minutes_in_default_zone_2) : [],
+                    borderColor: '#D4FF58',
+                    tension: 0.3
+                },
+                {
+                    label: 'Zona 3',
+                    data: trendData ? trendData.map(d => d.minutes_in_default_zone_3) : [],
+                    borderColor: '#F5F5F5',
+                    tension: 0.3
+                },
+            ],
+        };
+
+        const trendChartOptions = {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    grid: {
+                        color: 'rgba(117, 134, 128, 0.2)',
+                        drawBorder: false,
+                    },
+                    ticks: {
+                        color: '#758680',
+                    },
+                },
+                x: {
+                    grid: {
+                        display: false,
+                    },
+                    ticks: {
+                        color: '#F5F5F5',
+                    },
+                },
+            },
+            plugins: { legend: { display: false } },
+        };
         
         // Més espai vertical perquè el gràfic es vegi millor
         return (
@@ -196,9 +289,19 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData }) => {
                     {activeTab === 'hrZones' && hrZonesData && (
                         <Bar options={commonChartOptions} data={hrZonesChartData} />
                     )}
-                    {activeTab === 'tendencia' && (
+                    {activeTab === 'tendencia' && trendData && (
+                        <div style={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
+                            <div style={{ position: 'relative', flex: 1 }}>
+                                <Line options={trendChartOptions} data={trendIntensityData} />
+                            </div>
+                            <div style={{ position: 'relative', flex: 1 }}>
+                                <Line options={trendChartOptions} data={trendHrData} />
+                            </div>
+                        </div>
+                    )}
+                    {activeTab === 'tendencia' && !trendData && (
                         <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-                            <p>Pròximament...</p>
+                            <p>Carregant tendències...</p>
                         </div>
                     )}
                 </div>

--- a/frontend/src/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/components/Dashboard/Dashboard.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import useFitbitData from '../../hooks/useFitbitData';
+import useFitbitTrends from '../../hooks/useFitbitTrends';
 import useUserProfile from '../../hooks/useUserProfile';
 import './Dashboard.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -28,6 +29,7 @@ export default function Dashboard() {
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
   const [currentDate, setCurrentDate] = useState('');
   const { data: fitbitData, loading: isLoading, error } = useFitbitData();
+  const { data: trendData } = useFitbitTrends();
   const { data: profileData, refetch: refetchProfile } = useUserProfile();
 
   // Mostrem la data d'ahir amb la primera lletra en majúscula
@@ -221,14 +223,14 @@ export default function Dashboard() {
                 </div>
               </div>
               <div className="widget activity-charts-widget">
-                <ActivityWidget type="chartTabs" intensityData={intensityDataForChart} hrZonesData={hrZonesDataForChart} />
+                <ActivityWidget type="chartTabs" intensityData={intensityDataForChart} hrZonesData={hrZonesDataForChart} trendData={trendData} />
               </div>
               <BiomarkersWidget biomarkersData={biomarkersForWidget} />
             </div>
 
             {/* Column 3: Sleep Analysis i Condicions Mèdiques */}
             <div className="dashboard-section">
-              <SleepStagesWidget metricsData={sleepMetricsForWidget} stagesData={sleepStagesForWidget} />
+              <SleepStagesWidget metricsData={sleepMetricsForWidget} stagesData={sleepStagesForWidget} trendData={trendData} />
               <MedicalConditionsWidget conditions={medicalConditions} />
             </div>
           </main>

--- a/frontend/src/hooks/useFitbitTrends.js
+++ b/frontend/src/hooks/useFitbitTrends.js
@@ -1,0 +1,33 @@
+import { useState, useEffect } from "react";
+
+// Hook per obtenir les dades de tendències dels darrers 7 dies
+export default function useFitbitTrends() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    const fetchData = async () => {
+      try {
+        const r = await fetch("http://localhost:8000/fitbit-trends");
+        if (!r.ok) throw new Error(`HTTP error! status: ${r.status}`);
+        const j = await r.json();
+        if (active) {
+          setData(j);
+          setError(null);
+        }
+      } catch (e) {
+        if (active) setError(e);
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    fetchData();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
## Summary
- store last seven days of Fitbit data in new table
- expose `/fitbit-trends` endpoint
- fetch trend data on dashboard
- visualize trends for activity intensity, heart rate zones and sleep stages

## Testing
- `npm --prefix frontend run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d35eb2588331951a8d6fad88a9ee