### PR TITLE
Millores visuals en ActivityWidget i SleepStagesWidget

### DIFF
--- a/frontend/src/components/Dashboard/ActivityWidget.css
+++ b/frontend/src/components/Dashboard/ActivityWidget.css
@@ -34,7 +34,7 @@
 }
 
 .metrics-summary div span {
-    font-size: 1.8rem; /* Basado en docs/style.css */
+    font-size: 1.2rem; /* Mida reduïda per encabir al widget */
     font-weight: 700;
     display: block;
     color: var(--text-primary);
@@ -42,18 +42,18 @@
 }
 
 .metrics-summary div p {
-    font-size: 0.8rem; /* Basado en docs/style.css */
+    font-size: 0.6rem; /* Mida molt reduïda */
     color: var(--text-secondary);
     text-transform: uppercase;
-    margin-top: 4px;
+    margin-top: 2px;
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
 .metrics-summary div p .svg-inline--fa {
-    margin-right: 6px;
-    font-size: 0.9em; /* Ajustar tamaño del icono relativo al texto */
+    margin-right: 4px;
+    font-size: 0.7em; /* Icona més petita */
 }
 
 /* Chart Tabs Styling */
@@ -68,8 +68,8 @@
 }
 
 .tab-button {
-    padding: 8px 16px;
-    font-size: 0.85rem;
+    padding: 4px 8px;
+    font-size: 0.7rem;
     font-weight: 500;
     color: var(--text-secondary);
     background-color: transparent;
@@ -94,7 +94,7 @@
 .trend-chart-container {
     position: relative;
     width: 100%;
-    height: 200px;
-    margin-bottom: 15px;
+    height: 160px; /* Gràfic més compacte */
+    margin-bottom: 10px;
 }
 

--- a/frontend/src/components/Dashboard/ActivityWidget.jsx
+++ b/frontend/src/components/Dashboard/ActivityWidget.jsx
@@ -204,7 +204,7 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                         intensityData.moderate,
                         intensityData.intense,
                     ] : [],
-                    backgroundColor: ['#758680', '#A5A5A5', '#D4FF58', '#F5F5F5'],
+                    backgroundColor: ['#758680', '#333333', '#D4FF58', '#F5F5F5'],
                     borderRadius: 4,
                     borderWidth: 0,
                     barPercentage: 0.6,
@@ -225,7 +225,7 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                         hrZonesData.inZone2,
                         hrZonesData.inZone3,
                     ] : [],
-                    backgroundColor: ['#758680', '#A5A5A5', '#D4FF58', '#F5F5F5'], // Palette colors
+                    backgroundColor: ['#758680', '#333333', '#D4FF58', '#F5F5F5'], // Palette colors
                     borderRadius: 4,
                     borderWidth: 0,
                     barPercentage: 0.6,
@@ -267,7 +267,7 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                             <div className="loading-message">Carregant dades de tendències...</div>
                         ) : error ? (
                             <div className="error-message">Error en carregar les dades de tendències</div>
-                        ) : trendLabels.length > 0 ? (
+                        ) : trendLabelsState.length > 0 ? (
                             <>
                             <div className="trend-chart-container">
                                 <h4>Activitat Diària (minuts)</h4>
@@ -313,11 +313,11 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                                         }
                                     }}
                                     data={{
-                                        labels: trendLabels,
+                                        labels: trendLabelsState,
                                         datasets: [
-                                            { 
-                                                label: 'Sedentari', 
-                                                data: trendIntensity.sedentary, 
+                                            {
+                                                label: 'Sedentari',
+                                                data: trendIntensityState.sedentary,
                                                 borderColor: '#758680', 
                                                 backgroundColor: 'rgba(117,134,128,0.3)', 
                                                 borderWidth: 2,
@@ -326,18 +326,18 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                                                 pointHoverRadius: 5
                                             },
                                             { 
-                                                label: 'Lleu', 
-                                                data: trendIntensity.light, 
-                                                borderColor: '#A5A5A5', 
-                                                backgroundColor: 'rgba(165,165,165,0.3)', 
+                                                label: 'Lleu',
+                                                data: trendIntensityState.light,
+                                                borderColor: '#333333',
+                                                backgroundColor: 'rgba(51,51,51,0.3)',
                                                 borderWidth: 2,
                                                 tension: 0.3, 
                                                 pointRadius: 3,
                                                 pointHoverRadius: 5
                                             },
                                             { 
-                                                label: 'Moderat', 
-                                                data: trendIntensity.moderate, 
+                                                label: 'Moderat',
+                                                data: trendIntensityState.moderate,
                                                 borderColor: '#D4FF58', 
                                                 backgroundColor: 'rgba(212,255,88,0.3)', 
                                                 borderWidth: 2,
@@ -346,8 +346,8 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                                                 pointHoverRadius: 5
                                             },
                                             { 
-                                                label: 'Intens', 
-                                                data: trendIntensity.intense, 
+                                                label: 'Intens',
+                                                data: trendIntensityState.intense,
                                                 borderColor: '#F5F5F5', 
                                                 backgroundColor: 'rgba(245,245,245,0.3)', 
                                                 borderWidth: 2,
@@ -403,11 +403,11 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                                         }
                                     }}
                                     data={{
-                                        labels: trendLabels,
+                                        labels: trendLabelsState,
                                         datasets: [
-                                            { 
-                                                label: 'Repòs', 
-                                                data: trendHr.below, 
+                                            {
+                                                label: 'Repòs',
+                                                data: trendHrState.below,
                                                 borderColor: '#758680', 
                                                 backgroundColor: 'rgba(117,134,128,0.3)', 
                                                 borderWidth: 2,
@@ -416,18 +416,18 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                                                 pointHoverRadius: 5
                                             },
                                             { 
-                                                label: 'Suau', 
-                                                data: trendHr.zone1, 
-                                                borderColor: '#A5A5A5', 
-                                                backgroundColor: 'rgba(165,165,165,0.3)', 
+                                                label: 'Suau',
+                                                data: trendHrState.zone1,
+                                                borderColor: '#333333',
+                                                backgroundColor: 'rgba(51,51,51,0.3)',
                                                 borderWidth: 2,
                                                 tension: 0.3, 
                                                 pointRadius: 3,
                                                 pointHoverRadius: 5
                                             },
                                             { 
-                                                label: 'Moderat', 
-                                                data: trendHr.zone2, 
+                                                label: 'Moderat',
+                                                data: trendHrState.zone2,
                                                 borderColor: '#D4FF58', 
                                                 backgroundColor: 'rgba(212,255,88,0.3)', 
                                                 borderWidth: 2,
@@ -436,8 +436,8 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                                                 pointHoverRadius: 5
                                             },
                                             { 
-                                                label: 'Pic', 
-                                                data: trendHr.zone3, 
+                                                label: 'Pic',
+                                                data: trendHrState.zone3,
                                                 borderColor: '#F5F5F5', 
                                                 backgroundColor: 'rgba(245,245,245,0.3)', 
                                                 borderWidth: 2,

--- a/frontend/src/components/Dashboard/SleepStagesWidget.css
+++ b/frontend/src/components/Dashboard/SleepStagesWidget.css
@@ -25,7 +25,7 @@
 }
 
 .sleep-widget .widget-title {
-    font-size: 1.1rem;
+    font-size: 0.9rem;
     font-weight: 600;
     margin-bottom: 15px;
     display: flex;
@@ -56,8 +56,8 @@
 }
 
 .sleep-widget .tab-button { /* Scoped to sleep-widget */
-    padding: 8px 16px;
-    font-size: 0.85rem;
+    padding: 4px 8px;
+    font-size: 0.7rem;
     font-weight: 500;
     color: var(--text-secondary);
     background-color: transparent;
@@ -124,8 +124,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 6px 0;
-    font-size: 0.85rem;
+    padding: 4px 0;
+    font-size: 0.75rem;
     /* border-bottom: 1px solid var(--border-color); */ /* Optional: cleaner without individual borders */
 }
 /* .stage-item:last-child { border-bottom: none; } */
@@ -157,15 +157,17 @@
 
 .stage-time {
     color: var(--text-secondary);
-    min-width: 50px;
+    min-width: 45px;
     text-align: right;
+    font-size: 0.7rem;
 }
 
 .stage-percentage {
     color: var(--text-primary);
     font-weight: 500;
-    min-width: 30px;
+    min-width: 25px;
     text-align: right;
+    font-size: 0.7rem;
 }
 
 /* Estils de la pestanya de mètriques */
@@ -208,13 +210,13 @@
 }
 
 .metric-card .metric-icon {
-    font-size: 1.3em; /* Icona més petita */
+    font-size: 1.1em; /* Icona encara més petita */
     color: var(--accent-color);
     margin-bottom: 6px;
 }
 
 .metric-card .metric-value {
-    font-size: 1.1em; /* Text més petit */
+    font-size: 0.9em; /* Text més petit */
     font-weight: 600; /* Pes de lletra lleugerament més clar */
     color: var(--text-primary);
     margin-bottom: 3px;
@@ -222,7 +224,7 @@
 }
 
 .metric-card .metric-label {
-    font-size: 0.65em; /* Text més petit */
+    font-size: 0.55em; /* Text encara més petit */
     color: var(--text-secondary);
     margin: 0;
     line-height: 1.2;
@@ -238,6 +240,6 @@
 .sleep-trend-chart {
     position: relative;
     width: 100%;
-    height: 200px;
+    height: 160px; /* Més compacte */
 }
 

--- a/frontend/src/components/Dashboard/SleepStagesWidget.jsx
+++ b/frontend/src/components/Dashboard/SleepStagesWidget.jsx
@@ -45,6 +45,12 @@ const SleepStagesWidget = ({ stagesData, metricsData, trendData = [], trendLabel
         return col;
     });
 
+    // Map per associar cada fase amb el seu color resolt
+    const colorMap = safeStages.reduce((acc, stage, idx) => {
+        acc[stage.name] = resolvedColors[idx];
+        return acc;
+    }, {});
+
     const chartData = {
         labels: safeStages.map(s => s.name),
         datasets: [{
@@ -170,18 +176,25 @@ const SleepStagesWidget = ({ stagesData, metricsData, trendData = [], trendLabel
                                     responsive: true,
                                     maintainAspectRatio: false,
                                     scales: {
-                                        y: { beginAtZero: true, grid: { color: 'rgba(117,134,128,0.2)', drawBorder: false } },
-                                        x: { grid: { display: false }, ticks: { color: '#F5F5F5' } }
+                                        y: {
+                                            beginAtZero: true,
+                                            grid: { color: 'rgba(117,134,128,0.2)', drawBorder: false },
+                                            ticks: { color: '#F5F5F5', font: { size: 10 } }
+                                        },
+                                        x: {
+                                            grid: { display: false },
+                                            ticks: { color: '#F5F5F5', font: { size: 10 } }
+                                        }
                                     },
                                     plugins: { legend: { display: false } }
                                 }}
                                 data={{
                                     labels: trendLabels,
                                     datasets: [
-                                        { label: 'Profund', data: trendData.map(d => d.deep), borderColor: 'var(--accent-color)', backgroundColor: 'rgba(212,255,88,0.3)', tension: 0.3 },
-                                        { label: 'Lleuger', data: trendData.map(d => d.light), borderColor: 'var(--text-secondary)', backgroundColor: 'rgba(117,134,128,0.3)', tension: 0.3 },
-                                        { label: 'REM', data: trendData.map(d => d.rem), borderColor: 'var(--text-primary)', backgroundColor: 'rgba(245,245,245,0.3)', tension: 0.3 },
-                                        { label: 'Despert', data: trendData.map(d => d.awake), borderColor: 'var(--border-color)', backgroundColor: 'rgba(51,51,51,0.3)', tension: 0.3 }
+                                        { label: 'Profund', data: trendData.map(d => d.deep), borderColor: colorMap['Profund'], backgroundColor: `${colorMap['Profund']}33`, tension: 0.3 },
+                                        { label: 'Lleuger', data: trendData.map(d => d.light), borderColor: colorMap['Lleuger'], backgroundColor: `${colorMap['Lleuger']}33`, tension: 0.3 },
+                                        { label: 'REM', data: trendData.map(d => d.rem), borderColor: colorMap['REM'], backgroundColor: `${colorMap['REM']}33`, tension: 0.3 },
+                                        { label: 'Despert', data: trendData.map(d => d.awake), borderColor: colorMap['Despert'], backgroundColor: `${colorMap['Despert']}33`, tension: 0.3 }
                                     ]
                                 }}
                             />


### PR DESCRIPTION
## Resum
- s'utilitzen els estats de tendència a `ActivityWidget.jsx` i es corregeixen els colors
- reduïdes les mides de les lletres i dels gràfics per encaixar al widget
- les línies de tendència a `SleepStagesWidget.jsx` utilitzen un mapa de colors concordant amb la llegenda
- ajustaments de mides i estil als fitxers CSS

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851de7550fc83319c223195ba690a1c