### PR TITLE
Actualitza gràfics i carregues de dades setmanals

### DIFF
--- a/frontend/src/components/Dashboard/ActivityWidget.jsx
+++ b/frontend/src/components/Dashboard/ActivityWidget.jsx
@@ -300,20 +300,24 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                         ) : trendLabels.length > 0 ? (
                             <>
                             <div className="trend-chart-container">
-                                <h4>Activitat Diària (minuts)</h4>
+                                <h4>Activitat Diària (h:m)</h4>
                                 <Line
                                     options={{
                                         responsive: true,
                                         maintainAspectRatio: false,
                                         scales: {
-                                            y: { 
-                                                beginAtZero: true, 
+                                            y: {
+                                                beginAtZero: true,
                                                 grid: { color: 'rgba(117,134,128,0.2)', drawBorder: false },
-                                                ticks: { color: '#F5F5F5' }
+                                                ticks: {
+                                                    color: '#F5F5F5',
+                                                    stepSize: 60,
+                                                    callback: value => formatMinutesToHoursAndMinutes(value)
+                                                }
                                             },
-                                            x: { 
-                                                grid: { display: false }, 
-                                                ticks: { color: '#F5F5F5' } 
+                                            x: {
+                                                grid: { display: false },
+                                                ticks: { color: '#F5F5F5' }
                                             }
                                         },
                                         plugins: { 
@@ -335,9 +339,7 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                                                 borderWidth: 1,
                                                 padding: 10,
                                                 callbacks: {
-                                                    label: function(context) {
-                                                        return `${context.dataset.label}: ${context.raw} min`;
-                                                    }
+                                                    label: context => `${context.dataset.label}: ${formatMinutesToHoursAndMinutes(context.raw)}`
                                                 }
                                             }
                                         }
@@ -390,20 +392,24 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                                 />
                             </div>
                             <div className="trend-chart-container">
-                                <h4>Zones de Freqüència Cardíaca (minuts)</h4>
+                                <h4>Zones de Freqüència Cardíaca (h:m)</h4>
                                 <Line
                                     options={{
                                         responsive: true,
                                         maintainAspectRatio: false,
                                         scales: {
-                                            y: { 
-                                                beginAtZero: true, 
+                                            y: {
+                                                beginAtZero: true,
                                                 grid: { color: 'rgba(117,134,128,0.2)', drawBorder: false },
-                                                ticks: { color: '#F5F5F5' }
+                                                ticks: {
+                                                    color: '#F5F5F5',
+                                                    stepSize: 60,
+                                                    callback: value => formatMinutesToHoursAndMinutes(value)
+                                                }
                                             },
-                                            x: { 
-                                                grid: { display: false }, 
-                                                ticks: { color: '#F5F5F5' } 
+                                            x: {
+                                                grid: { display: false },
+                                                ticks: { color: '#F5F5F5' }
                                             }
                                         },
                                         plugins: { 
@@ -425,9 +431,7 @@ const ActivityWidget = ({ data, type, intensityData, hrZonesData, trendLabels = 
                                                 borderWidth: 1,
                                                 padding: 10,
                                                 callbacks: {
-                                                    label: function(context) {
-                                                        return `${context.dataset.label}: ${context.raw} min`;
-                                                    }
+                                                    label: context => `${context.dataset.label}: ${formatMinutesToHoursAndMinutes(context.raw)}`
                                                 }
                                             }
                                         }

--- a/frontend/src/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/components/Dashboard/Dashboard.jsx
@@ -30,7 +30,14 @@ export default function Dashboard() {
   const [currentDate, setCurrentDate] = useState('');
   const { data: fitbitData, loading: isLoading, error } = useFitbitData();
   const { data: profileData, refetch: refetchProfile } = useUserProfile();
-  const { data: weeklyData } = useWeeklyData();
+  const { data: weeklyData, refetch: refetchWeekly } = useWeeklyData();
+
+  // Quan arriben les dades diàries, refresquem les setmanals per tenir les tendències actualitzades
+  useEffect(() => {
+    if (!isLoading) {
+      refetchWeekly();
+    }
+  }, [isLoading]);
 
   // Mostrem la data d'ahir amb la primera lletra en majúscula
   useEffect(() => {

--- a/frontend/src/components/Dashboard/SleepStagesWidget.jsx
+++ b/frontend/src/components/Dashboard/SleepStagesWidget.jsx
@@ -170,10 +170,29 @@ const SleepStagesWidget = ({ stagesData, metricsData, trendData = [], trendLabel
                                     responsive: true,
                                     maintainAspectRatio: false,
                                     scales: {
-                                        y: { beginAtZero: true, grid: { color: 'rgba(117,134,128,0.2)', drawBorder: false } },
+                                        y: {
+                                            beginAtZero: true,
+                                            grid: { color: 'rgba(117,134,128,0.2)', drawBorder: false },
+                                            ticks: {
+                                                color: '#F5F5F5',
+                                                stepSize: 60,
+                                                callback: value => formatMinutesToHoursAndMinutes(value)
+                                            }
+                                        },
                                         x: { grid: { display: false }, ticks: { color: '#F5F5F5' } }
                                     },
-                                    plugins: { legend: { display: false } }
+                                    plugins: {
+                                        legend: {
+                                            display: true,
+                                            position: 'top',
+                                            labels: { color: '#F5F5F5', usePointStyle: true, pointStyle: 'circle', padding: 20 }
+                                        },
+                                        tooltip: {
+                                            callbacks: {
+                                                label: ctx => `${ctx.dataset.label}: ${formatMinutesToHoursAndMinutes(ctx.raw)}`
+                                            }
+                                        }
+                                    }
                                 }}
                                 data={{
                                     labels: trendLabels,

--- a/frontend/src/hooks/useWeeklyData.js
+++ b/frontend/src/hooks/useWeeklyData.js
@@ -6,38 +6,26 @@ export default function useWeeklyData() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    let mounted = true;
-
-    const fetchWeek = async () => {
-      try {
-        console.log('Fetching data from /fitbit-weekly...');
-        const r = await fetch("http://localhost:8000/fitbit-weekly");
-        const j = await r.json();
-        console.log('API Response:', j);
-        if (!r.ok) {
-          console.error('API Error:', j.detail || r.statusText);
-          throw new Error(j.detail || r.statusText);
-        }
-        if (mounted) {
-          console.log('Setting data in state');
-          setData(j);
-          setError(null);
-        }
-      } catch (e) {
-        console.error('Error in fetchWeek:', e);
-        if (mounted) setError(e);
-      } finally {
-        if (mounted) setLoading(false);
+  const fetchWeek = async () => {
+    try {
+      const r = await fetch("http://localhost:8000/fitbit-weekly");
+      const j = await r.json();
+      if (!r.ok) {
+        throw new Error(j.detail || r.statusText);
       }
-    };
+      setData(j);
+      setError(null);
+    } catch (e) {
+      setError(e);
+    } finally {
+      setLoading(false);
+    }
+  };
 
+  useEffect(() => {
     fetchWeek();
-    return () => {
-      mounted = false;
-    };
   }, []);
 
-  return { data, loading, error };
+  return { data, loading, error, refetch: fetchWeek };
 }
 


### PR DESCRIPTION
## Resum
- refresc automàtic de `fitbit-weekly` després de carregar `fitbit-data`
- nou `refetch` al hook `useWeeklyData`
- millores visuals dels gràfics de tendències (hores i minuts)

## Testing
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68529a5949c48331a79be0e4f1b1868c